### PR TITLE
Add file logging for LLM requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ cover/
 
 # Django stuff:
 *.log
+log.txt
 local_settings.py
 db.sqlite3
 db.sqlite3-journal

--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -10,6 +10,19 @@ from langchain_openai import ChatOpenAI
 
 logger = logging.getLogger(__name__)
 
+# Add a file handler to persist LLM requests and responses.
+# This is done lazily to avoid adding duplicate handlers when the module
+# is imported multiple times during tests or execution.
+if not any(isinstance(h, logging.FileHandler) for h in logger.handlers):
+    file_handler = logging.FileHandler("log.txt", encoding="utf-8")
+    file_handler.setLevel(logging.INFO)
+    file_handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+    )
+    logger.addHandler(file_handler)
+
 
 class LoggingChatOpenAI:
     """Wrapper around ChatOpenAI that logs requests and responses."""


### PR DESCRIPTION
## Summary
- log every LLM request/response to `log.txt`
- ignore generated log file

## Testing
- `make format` *(fails: Failed to fetch `langchain-experimental`)*
- `make lint` *(fails: Failed to fetch `uvicorn`)*
- `make test` *(fails: Failed to fetch `pytest-cov`)*

------
https://chatgpt.com/codex/tasks/task_e_684f86bd1944832ebc0a049a9d53d900